### PR TITLE
Deploy containers to registry with simple rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Include:
     - metadata.rb
+    - Rakefile
     - '**/Gemfile'
     - attributes/**/*
     - definitions/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'chef', '~> 11.12.2'
+gem 'chef', '~> 12'
 gem 'berkshelf'
 
 group :integration do
@@ -14,4 +14,5 @@ group :integration do
   gem 'serverspec'
   gem 'chefspec'
   gem 'foodcritic'
+  gem 'knife-container'
 end

--- a/README.md
+++ b/README.md
@@ -23,16 +23,35 @@ If you are a vagrant user, you can use the `Vagrantfile` at the root of the repo
 
 After vm converged, you can ssh and play with `knife container` commands.
 
-##### Example to build a ruby container:
+### Example to build a ruby container:
 
-###### First, install dependencies:
+#### With Rake
+
+This method only works if you have docker installed on your system.
+
+```
+$ bundle install
+$ bundle exec rake container:prepare_ruby #-> or simply `prepare` to prepare all containers
+$ bundle exec rake container:create_ruby #-> or simply `create` to create all containers
+$ bundle exec rake container:deploy_ruby[my_registry.com] #-> or simply `deploy` to deploy container to `my_registry.com`
+```
+
+It's also possible to directory prepare, create and deploy all containers.
+
+```
+$ bundle install
+$ bundle exec rake container:all[my_registry.com]
+```
+
+
+#### With vagrant
 
 ```
 $ bundle install
 $ bundle exec berks vendor cookbooks
 ```
 
-###### And run vagrant:
+##### And run vagrant:
 
 ```
 $ vagrant up

--- a/Rakefile
+++ b/Rakefile
@@ -17,22 +17,17 @@ def bundle_exec(command)
   sh "bundle exec #{command}"
 end
 
-task :vendor do
-  sh 'test -d cookbooks && rm -r cookbooks || exit 0'
-  bundle_exec 'berks vendor cookbooks'
+task :vendor, [:directory] do |_t, args|
+  directory = args[:directory] || 'cookbooks'
+  rm_rf directory
+  bundle_exec "berks vendor #{directory}"
 end
 
 namespace :test do
   desc 'Tests suites runner'
 
-  task :checkstyle do
-    Rake::Task['test:foodcritic'].invoke
-    Rake::Task['test:rubocop'].invoke
-  end
-
-  task :specs do
-    Rake::Task['test:chefspec'].invoke
-  end
+  task checkstyle: [:foodcritic, :rubocop]
+  task specs: [:chefspec]
 
   task :foodcritic do
     bundle_exec 'foodcritic -f any .'
@@ -49,6 +44,50 @@ namespace :test do
   task :kitchen do
     bundle_exec 'kitchen test'
   end
+end
+
+namespace :container  do
+  current_dir = File.dirname(__FILE__)
+  h = { 'java' => 'jenv',
+        'node_js' => 'ndenv',
+        'php' => 'phpenv',
+        'python' => 'pyenv',
+        'ruby' => 'rbenv' }
+
+  h.each do |name, recipe|
+    task "prepare_#{name}".to_sym => [:vendor] do
+      sh "knife container docker init builder/#{name} -r " \
+      "'recipe[container::#{recipe}]' " \
+      "--cookbook-path #{current_dir}/cookbooks" \
+      " --dockerfiles-path #{current_dir}/dockerfiles -z --force"
+      sh "tar -zc --exclude .git --directory #{current_dir} cookbooks" \
+      " | tar -xz -C #{current_dir}/dockerfiles/builder/#{name}/chef/"
+    end
+
+    task "create_#{name}".to_sym do
+      sh "knife container docker build builder/#{name} --no-berks" \
+      " -z --dockerfiles #{current_dir}/dockerfiles/"
+    end
+  end
+
+  multitask prepare: h.map { |name, _recipe| "prepare_#{name}".to_sym }
+  multitask create: h.map { |name, _recipe| "create_#{name}".to_sym }
+
+  task :deploy, [:repository] do |_t, args|
+    repository = "#{args[:repository]}/" unless args[:repository].nil?
+    h.each do |name, _recipe|
+      task "deploy_#{name}" do
+        sh "docker tag -f $(docker images | grep builder/#{name} | " \
+        "grep latest | awk '{ print $3 }') #{repository}#{name}-builder"
+        sh "docker push #{repository}#{name}-builder"
+      end
+    end
+
+    multitask parallel_deploy: h.map { |name, _recipe| "deploy_#{name}".to_sym }
+    Rake::MultiTask[:parallel_deploy].invoke
+  end
+
+  task :all, [:repository] => [:prepare, :create, :deploy]
 end
 
 task default: ['test:checkstyle', 'test:specs']

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -15,7 +15,7 @@
 require_relative 'spec_helper'
 
 describe 'container::builder' do
-  subject { ChefSpec::Runner.new.converge(described_recipe) }
+  subject { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it 'does include docker recipe' do
     expect(subject).to include_recipe('docker')

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -15,7 +15,7 @@
 require_relative 'spec_helper'
 
 describe 'container::default' do
-  subject { ChefSpec::Runner.new.converge(described_recipe) }
+  subject { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it 'does include apt recipe' do
     expect(subject).to include_recipe('apt')

--- a/spec/jenv_spec.rb
+++ b/spec/jenv_spec.rb
@@ -16,7 +16,7 @@ require_relative 'spec_helper'
 
 describe 'container::jenv' do
   let(:subject) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.set['container']['jenv']['versions'] = ['42']
       node.set['container']['jenv']['plugins']['enable'] = ['groovy']
       node.set['container']['jenv']['plugins']['disable'] = ['maven']

--- a/spec/ndenv_spec.rb
+++ b/spec/ndenv_spec.rb
@@ -16,7 +16,7 @@ require_relative 'spec_helper'
 
 describe 'container::ndenv' do
   let(:subject) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.set['container']['ndenv']['versions'] = ['0.10.26', '0.10.33']
       node.set['container']['ndenv']['global'] = '0.10.26'
       node.set['container']['ndenv']['packages'] = ['grunt', 'grunt-cli']

--- a/spec/phpenv_spec.rb
+++ b/spec/phpenv_spec.rb
@@ -16,7 +16,7 @@ require_relative 'spec_helper'
 
 describe 'container::phpenv' do
   let(:subject) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.set['container']['phpenv']['versions'] = ['5.3.29', '5.4.2']
       node.set['container']['phpenv']['global'] = '5.3.29'
     end.converge described_recipe

--- a/spec/pyenv_spec.rb
+++ b/spec/pyenv_spec.rb
@@ -16,7 +16,7 @@ require_relative 'spec_helper'
 
 describe 'container::pyenv' do
   let(:subject) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.set['container']['pyenv']['versions'] = ['2.7.6', '3.3.3', '3.4-dev']
       node.set['container']['pyenv']['global'] = '3.3.3'
       node.set['container']['pyenv']['packages'] = ['tox']

--- a/spec/rbenv_spec.rb
+++ b/spec/rbenv_spec.rb
@@ -16,7 +16,7 @@ require_relative 'spec_helper'
 
 describe 'container::rbenv' do
   let(:subject) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.set['container']['rbenv']['versions'] = ['1.9.3-p547',
                                                     '2.0.0-p598',
                                                     '2.1.0-rc1']


### PR DESCRIPTION
Add Rakefile in .rubocop.yml
Add knife container and fix chef version to 12
Add tasks in Rakefile to prepare, create and deploy containers
created by knife container into a registry plus little refactoring
therein.
More I fixed deprecated warnings from chefspec (SoloRunner instead of Runner)