### PR TITLE
Add curl to containers

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 
 override['locale']['lang'] = 'en_US.UTF-8'
 override['locale']['lc_all'] = 'en_US.UTF-8'
+default['container']['packages'] = %w(curl)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,3 +19,7 @@
 include_recipe 'apt'
 include_recipe 'build-essential'
 include_recipe 'locale'
+
+node['container']['packages'].each do |pkg|
+  package pkg
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -28,4 +28,8 @@ describe 'container::default' do
   it 'does include locale recipe' do
     expect(subject).to include_recipe('locale')
   end
+
+  it 'does install packege curl' do
+    expect(subject).to install_package('curl')
+  end
 end


### PR DESCRIPTION
Add the curl package install on containers

Curl is needed on some cookbooks to get other packages (composer for example)
